### PR TITLE
explicitly specify the encoding when open files

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -31,7 +31,7 @@ text_path = './translation.toml'
 
 def get_config(path):
     if osp.exists(path):
-        return pytoml.load(open(path))
+        return pytoml.load(open(path, "r", encoding="UTF-8"))
     else:
         logger.error("Missing config file! Shutting down now...")
         sys.exit(1)
@@ -41,6 +41,7 @@ class Fetcher(object):
     def __init__(self, bot, delay=5, retry=30):
         self.bot = bot
         self.delay = self._parse_delay(delay)
+
         async def task():
             delta = self._till_next_time(minimum=10)
             print(f'Next update is scheduled in {delta} seconds.')

--- a/cache.py
+++ b/cache.py
@@ -30,12 +30,12 @@ class Cache(object):
 
     def save(self, key, obj):
         path = osp.join(self.cache_root, key)
-        with open(path, "w") as cache:
+        with open(path, "w", encoding="UTF-8") as cache:
             json.dump(obj, cache)
 
     def load(self, key) -> Option:
         path = osp.join(self.cache_root, key)
         if not osp.exists(path):
             return Option(None)
-        with open(path) as cache:
+        with open(path, "r", encoding="UTF-8") as cache:
             return Option(json.load(cache))


### PR DESCRIPTION
To make sure the bot can open files by correct encoding on some OS that using GBK as default encoding, especially the Windows Server in Simplified Chinese.
